### PR TITLE
Adding one bootstrap file that works for AWS Linux 2023 image

### DIFF
--- a/RDS_Demo/bootstrap-aws-linux-image-2023.sh
+++ b/RDS_Demo/bootstrap-aws-linux-image-2023.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+yum update -y
+sudo dnf install mariadb105-server -y


### PR DESCRIPTION
When following the https://learn.acloud.guru/course/aws-certified-developer-associate/learn/d08a2b54-37e1-d237-21a7-55eea7c0fb2d/c487e6ac-4d0e-b4d8-2e25-4821a391fcfa/watch video, I noticed that the provided bootstrap file doesn't work for AWS Linux AMI 2023. 

When searching in the A Cloud Guru Forum, I saw that somebody had provided a solution for this at this link: https://acloud.guru/forums/aws-cda-2018/discussion/-NRbLUIK9kRD60W_XcwX/trying-rds-demo-aws-certified-developer-course-failing-to-install-mysql?answer=-NRbyxvSXrHfYxe9vTle

Thus I wanted to contribute by creating a new file that would work for the AWS 2023 Linux image. I tested the command and it doesn't work without the sudo, so I left the sudo dnf command in the file. Once instance is launched, mysql will have been installed. 

Please, kindly review this request. Thanks in advance. 