### PR TITLE
Change the way to install mysql client for amazon linux 2023

### DIFF
--- a/RDS_Demo/bootstrap.sh
+++ b/RDS_Demo/bootstrap.sh
@@ -1,3 +1,4 @@
 #!/bin/bash  
-yum update -y
-yum install mysql -y
+sudo dnf update -y
+sudo dnf install mariadb105-server
+


### PR DESCRIPTION
For amazon linux 2023 yum install mysql doesn't work any more