### PR TITLE
Update index.js to prevent lambda aws error

### DIFF
--- a/creating-a-lambda-function-using-the-aws-console/index.js
+++ b/creating-a-lambda-function-using-the-aws-console/index.js
@@ -1,7 +1,7 @@
-const https = require('https')
+import https from 'https'
 let url = "https://www.amazon.com" 
 
-exports.handler = function(event, context, callback) { 
+export const handler = function(event, context, callback) { 
 	https.get(url, (res) => { 
   		    callback(null, res.statusCode) 	
     	}).on('error', (e) => { 


### PR DESCRIPTION
When you upload the last code lambda function send this error:

Response
{
  "errorType": "ReferenceError",
  "errorMessage": "exports is not defined in ES module scope",
  "trace": [
    "ReferenceError: exports is not defined in ES module scope",
    "    at file:///var/task/index.mjs:4:1",
    "    at ModuleJob.run (node:internal/modules/esm/module_job:194:25)"
  ]
}

I modified the code to prevent the error in lambda tests.